### PR TITLE
Create directories /lib/firmware/rtlwifi before copying bin file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,9 @@ install:
 	install -p -m 644 8188eu.ko  $(MODDESTDIR)
 	@if [ -a /lib/modules/$(KVER)/kernel/drivers/staging/rtl8188eu/r8188eu.ko ] ; then modprobe -r r8188eu; fi;
 	@echo "blacklist r8188eu" > /etc/modprobe.d/50-8188eu.conf
+	mkdir -p /lib/firmware/rtlwifi
 	cp rtl8188eufw.bin /lib/firmware/.
 	/sbin/depmod -a ${KVER}
-	mkdir -p /lib/firmware/rtlwifi
 	cp rtl8188eufw.bin /lib/firmware/rtlwifi/.
 
 uninstall:

--- a/README.md
+++ b/README.md
@@ -1,31 +1,28 @@
-<b>TL-WN725N-TP-Link- driver for Debian and Derivates o.s.</b>
+# TL-WN725N-TP-Link Driver for Debian and Derivates
 
 
 <img src="https://github.com/ilnanny/TL-WN725N-TP-Link-Debian/blob/master/TP_Link_TL_WN725N_Debian_ilnanny.jpg" alt="TL-WN725N-TP-Link- driver for Debian and Derivates o.s" />
 
+**Note**: Use `su` in terminal emulator
 
-<b>Use su in terminal emulator.
+1. Install dependencies
+    ``` bash
+    apt-get update
+    apt-get install linux-headers-$(uname -r)
+    apt-get install build-essential
+    ```
+2. Clone repository
 
-apt-get update
-apt-get install linux-headers-$(uname -r)
+    ``` bash
+    git clone https://github.com/ilnanny/TL-WN725N-TP-Link-Debian.git
+    ```
+3. Build and Install
+    ``` bash
+    cd TL-WN725N-TP-Link-Debian
+    make all
+    make install
+    insmod 8188eu.ko
+    ```
+    You can check to see if your wireless wlan cards is now listed using `ifconfig` or `ip a`
 
-apt-get update
-apt-get install build-essential
-
-git clone https://github.com/ilnanny/TL-WN725N-TP-Link-Debian.git
-
-cd TL-WN725N-TP-Link-Debian
-
-make all
-
-su 
-
-make install
-
-insmod 8188eu.ko
-
- ifconfig 
-(check to see if your wireless wlan cards is now listed)
-
-
-reboot</b>
+4. Reboot


### PR DESCRIPTION
Moved the command `mkdir -p /lib/firmware/rtlwifi` before copying the bin file.
I also updated the Readme file markup to look better